### PR TITLE
Fix bugs in interface_generator and reorder imports in hetero_searching

### DIFF
--- a/interfacemaster/hetero_searching.py
+++ b/interfacemaster/hetero_searching.py
@@ -1,3 +1,5 @@
+from numpy import *
+from numpy.linalg import *
 from pymatgen.analysis.interfaces.substrate_analyzer import SubstrateAnalyzer
 from pymatgen.core.structure import Structure
 from pymatgen.analysis.interfaces.zsl import ZSLGenerator, ZSLMatch, reduce_vectors
@@ -5,8 +7,6 @@ from pymatgen.core.surface import SlabGenerator
 from interfacemaster.cellcalc import get_primitive_hkl, get_pri_vec_inplane, get_normal_index, get_normal_from_MI, rot
 from interfacemaster.interface_generator import core, convert_vector_index, get_disorientation
 from interfacemaster.tool import get_indices_from_cart
-from numpy import *
-from numpy.linalg import *
 import os
 import shutil
 import json

--- a/interfacemaster/interface_generator.py
+++ b/interfacemaster/interface_generator.py
@@ -1667,7 +1667,6 @@ class core:
                 'failed to find a satisfying appx CSL. '
                 'Try to adjust the limits according'
                 'to the log file generated; or try another orientation.')
-    """"""
     #def specified_matching(hkl_substrate, hkl_film, B_substrate, B_film):
         """
         lattice matching by specified indices
@@ -1684,7 +1683,6 @@ class core:
             plane basis of film
         __________
         """
-    """"""
         
 
     def search_all_position(
@@ -2464,12 +2462,18 @@ class hetero_generator:
         film_miller,
         substrate_structure,
         film_structure,
-        )
+        ):
+        self.substrate_sl_vectors = substrate_sl_vectors
+        self.film_sl_vectors = film_sl_vectors
+        self.substrate_miller = substrate_miller
+        self.film_miller = film_miller
+        self.substrate_structure = substrate_structure
+        self.film_structure = film_structure
     
-    def csl_cnid_calc():
-        transformation = from_2D_to_3D_transformation(substrate_sl_vectors, film_sl_vectors)
-        B_substrate = get_pri_vec_inplane(substrate_miller, substrate_structure.lattice.matrix.T)
-        B_film = get_pri_vec_inplane(film_miller, film_structure.lattice.matrix.T)
+    def csl_cnid_calc(self):
+        transformation = from_2D_to_3D_transformation(self.substrate_sl_vectors, self.film_sl_vectors)
+        B_substrate = get_pri_vec_inplane(self.substrate_miller, self.substrate_structure.lattice.matrix.T)
+        B_film = get_pri_vec_inplane(self.film_miller, self.film_structure.lattice.matrix.T)
         B_film = dot(transformation, B_film)
         calc = DSCcalc()
         calc.parse_int_U(B_substrate, B_film, 200)
@@ -2478,5 +2482,6 @@ class hetero_generator:
         self.CSL = calc.CSL
         self.CNID = calc.CNID
     
-    def find_c():
-        
+    def find_c(self):
+        # placeholder
+        pass


### PR DESCRIPTION
## Summary
Fix syntax errors and import order bugs.

## Changes
- interface_generator l1670: remove block comments (that caused SyntaxError)
- interface_generator l2459: fix __init__ missing colon and instance variable assignments
- interface_generator l2469~: add self parameter to csl_cnid_calc and find_c
- hetero_searching: reorder imports to prevent numpy.core from overwriting interfacemaster.interface_generator.core